### PR TITLE
Include invoice notes in WhatsApp invoices

### DIFF
--- a/index.html
+++ b/index.html
@@ -624,7 +624,8 @@ function sendInvoiceWA(invId){
   const inv = state.invoices.find(i=> i.id === invId); if(!inv) return;
   if(inv.status !== 'unpaid') return showToast('Resend is allowed only for Unpaid invoices', true);
   const c = state.customers.find(x=> x.id === inv.customerId); if(!c || !c.phoneStored) return showToast('Customer phone missing', true);
-  const text = `Hello ${firstName(c.name)}, your Vaalpark Laundry invoice #${inv.number}.\nAmount: R${Number(inv.amount).toFixed(2)}.\nStatus: Unpaid.\nYou currently have ${c.stamps || 0} out of ${STAMPS_REQUIRED} stamps.`;
+  const commentLine = inv.notes ? `\nComments: ${inv.notes}` : '';
+  const text = `Hello ${firstName(c.name)}, your Vaalpark Laundry invoice #${inv.number}.\nAmount: R${Number(inv.amount).toFixed(2)}.\nStatus: Unpaid.\nYou currently have ${c.stamps || 0} out of ${STAMPS_REQUIRED} stamps.${commentLine}`;
   openWhatsAppDesktop(c.phoneStored, text);
   showToast('Invoice message opened in WhatsApp');
 }


### PR DESCRIPTION
## Summary
- Append customer invoice notes to WhatsApp invoice messages when present

## Testing
- `node - <<'NODE'
const fs = require('fs');
const html = fs.readFileSync('index.html','utf8');
const funcMatch = html.match(/function sendInvoiceWA\(invId\){[\s\S]*?\n\s*}/);
eval(funcMatch[0]);
const STAMPS_REQUIRED=10;
const state={invoices:[{id:1, status:'unpaid', customerId:1, number:'001', amount:100, notes:'This is a test note'}], customers:[{id:1, name:'John Doe', phoneStored:'12345', stamps:3}]};
function showToast(msg, err){ console.log('Toast:', msg, err); }
function firstName(name){ return name.split(' ')[0]; }
function openWhatsAppDesktop(phone, message){ console.log('Message:', message); }
sendInvoiceWA(1);
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68a80bcdb94c8325aeab98355aa0e9f7