### PR TITLE
Include invoice comments in initial WhatsApp message

### DIFF
--- a/index.html
+++ b/index.html
@@ -510,8 +510,9 @@ function createInvoice(sendWA){
   saveAll(); renderStampDisplay(c); renderVouchers(c); renderTransactionsForCustomer(c); renderCustomerList(); renderInvoices();
   inputAmount.value=''; inputNotes.value=''; inputInvoiceNumber.value='';
 
-  if(sendWA){ 
-    const text = `Hello ${firstName(c.name)}, your Vaalpark Laundry invoice #${inv.number} has been created.\nAmount: R${inv.amount.toFixed(2)}.\nStatus: Unpaid.\nYou currently have ${c.stamps || 0} out of ${STAMPS_REQUIRED} stamps.`;
+  if(sendWA){
+    const commentLine = inv.notes ? `\nComments: ${inv.notes}` : '';
+    const text = `Hello ${firstName(c.name)}, your Vaalpark Laundry invoice #${inv.number} has been created.\nAmount: R${inv.amount.toFixed(2)}.\nStatus: Unpaid.\nYou currently have ${c.stamps || 0} out of ${STAMPS_REQUIRED} stamps.${commentLine}`;
     openWhatsAppDesktop(c.phoneStored, text);
   }
   showToast('Invoice created');


### PR DESCRIPTION
## Summary
- Include invoice comments in the initial WhatsApp message when creating an invoice

## Testing
- `npm test` *(fails: could not read package.json)*
- `node <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_68a811bf26ec8325af70827f1ab7f6a8